### PR TITLE
Fixed eMMC detection

### DIFF
--- a/pkg/arch-arm/uboot-odroid/sd_fusing.sh
+++ b/pkg/arch-arm/uboot-odroid/sd_fusing.sh
@@ -98,7 +98,7 @@ exit_trap() {
 #   1 - otherwise
 is_mmc() {
   local dev="$1"
-  [ -d "/sys/block/${dev##*/}/boot0" ]
+  [ -d "/sys/block/${dev##*/}boot0" ]
 }
 
 # Determine whether the given partition of an MMC device is writable.


### PR DESCRIPTION
There is no `/sys/block/mmcblk0/boot0`, instead, there is `/sys/block/mmcblk0boot0`.

Without this fix, my eMMC was detected as SD card and it corrupted my eMMC `/sys/block/mmcblk0`.
